### PR TITLE
Fix an IP issue from ip_check function

### DIFF
--- a/docker/rabbitmq_flower/ip_check.sh
+++ b/docker/rabbitmq_flower/ip_check.sh
@@ -21,7 +21,7 @@ check() {
             fi
         done
     elif [ $NUM -eq 1 ]; then
-        IP=$ip
+        IP=$IPs
     fi
 
     echo $IP


### PR DESCRIPTION
When there is only one IP address this function didn't return any IP
address. Now it returns that IP.