### PR TITLE
Add rebuild the flower docker image

### DIFF
--- a/docker/rabbitmq_flower/service.sh
+++ b/docker/rabbitmq_flower/service.sh
@@ -109,6 +109,12 @@ case "$1" in
         start_rabbitmq
         start_flower
         ;;
+    --build)
+        stop_containers
+        delete_flower
+        start_rabbitmq
+        start_flower
+        ;;
     *)
         help $0
 esac

--- a/docker/rabbitmq_flower/service.sh
+++ b/docker/rabbitmq_flower/service.sh
@@ -87,6 +87,10 @@ stop_containers() {
     done
 }
 
+delete_flower() {
+    docker rmi $FLOWER_NAME
+}
+
 help() {
     echo "usage:\t[--start]\tstart RabbitMQ and Flower services"
     echo "$fakes\t[--stop]\tstop and delete containers"

--- a/docker/rabbitmq_flower/service.sh
+++ b/docker/rabbitmq_flower/service.sh
@@ -94,6 +94,8 @@ delete_flower() {
 help() {
     echo "usage:\t[--start]\tstart RabbitMQ and Flower services"
     echo "$fakes\t[--stop]\tstop and delete containers"
+    echo "$fakes\t[--restart]\tstop, delete and start containers"
+    echo "$fakes\t[--build]\tstop and delete containers. Delete the flower image and start containers again"
 }
 
 case "$1" in


### PR DESCRIPTION
This PR does:
* Adds a delete flower docker image function
* Adds a new argument called `--build` to:
  * Stop and delete the RabbitMQ and Flower docker containers
  * Delete the flower docker image
  * Build the flower docker image
  * Start the RabbitMQ and Flower docker containers
* Adds the `--restart` and `--build` arguments to the help message